### PR TITLE
Reject tokens with overly long validity, reorder validity checks

### DIFF
--- a/crtauth/rsa.py
+++ b/crtauth/rsa.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2014 Spotify AB
+# Copyright (c) 2011-2015 Spotify AB
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/test/roundtrip_test.py
+++ b/test/roundtrip_test.py
@@ -191,6 +191,15 @@ class RoundtripTest(unittest.TestCase):
         except exceptions.InvalidInputException:
             pass
 
+    def test_create_token_invalid_duration(self):
+        auth_server = server.AuthServer("server_secret", DummyKeyProvider(),
+                                        "server.name")
+        token = auth_server._make_token("some_user", int(time.time()) + 3600)
+
+        self.assertRaises(exceptions.InvalidInputException,
+                          auth_server.validate_token, token)
+
+
     def test_create_token_too_old(self):
         auth_server_a = server.AuthServer("server_secret", DummyKeyProvider(),
                                           "server.name")


### PR DESCRIPTION
Some classes of attacks require a lot of guesses before an
authentication code or signature can be guessed. By making sure
that we verify the time limits on a token before we verify the
authentication we prevent an attacker testing combination for a
long time.